### PR TITLE
⚡ Bolt: Add GZip compression to backend responses

### DIFF
--- a/back/src/main.py
+++ b/back/src/main.py
@@ -6,6 +6,7 @@ import typing
 import strawberry
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from strawberry.fastapi import GraphQLRouter
 from fastapi.staticfiles import StaticFiles
 
@@ -40,6 +41,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+# ⚡ Bolt: Added GZip middleware to compress large GraphQL responses (e.g. lists of cards/sets)
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 schema = strawberry.Schema(Query)
 graphql_app = GraphQLRouter(schema)


### PR DESCRIPTION
💡 What: Added FastAPI GZipMiddleware to `back/src/main.py`
🎯 Why: GraphQL responses, especially for fetching large sets of cards, can be significantly large, taking a longer time to be downloaded over the network.
📊 Impact: Compresses responses greater than 1000 bytes. This reduces payload size significantly and decreases network time for the Flutter application without significantly impacting CPU load on the backend.
🔬 Measurement: Use `measure_compression.py` or inspect browser/client network requests to verify `Content-Encoding: gzip`.

---
*PR created automatically by Jules for task [18117360087484344491](https://jules.google.com/task/18117360087484344491) started by @Akenaide*