### PR TITLE
⚡ Bolt: Add GZIP compression to API responses

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - GraphQL Payload Compression
+**Learning:** GraphQL endpoints can easily return large JSON payloads, especially for lists of sets or cards. Without compression, these payloads unnecessarily consume bandwidth and increase load times for frontend clients.
+**Action:** Added `GZipMiddleware` to the FastAPI backend to automatically compress large API responses (above 1000 bytes) and significantly reduce transfer sizes.

--- a/back/src/main.py
+++ b/back/src/main.py
@@ -6,6 +6,7 @@ import typing
 import strawberry
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from strawberry.fastapi import GraphQLRouter
 from fastapi.staticfiles import StaticFiles
 
@@ -33,6 +34,7 @@ class Query:
 
 app = FastAPI(lifespan=lifespan)
 app.mount("/medias", StaticFiles(directory=settings.medias_dir), name="medias")
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
💡 **What:** Added `GZipMiddleware` to the FastAPI backend to automatically compress HTTP responses larger than 1000 bytes.
🎯 **Why:** GraphQL queries, especially those fetching lists of sets or cards (like in search or scrolling), return large JSON payloads. This uncompressed data consumes unnecessary bandwidth and increases load times for the Flutter client.
📊 **Impact:** Significantly reduces network transfer sizes for JSON payloads, improving API response time and saving bandwidth.
🔬 **Measurement:** Can be verified by inspecting network requests in the browser or via curl (e.g., `curl -H "Accept-Encoding: gzip" <api-url>`), observing that the `Content-Encoding: gzip` header is present and the transferred payload size is much smaller than the raw JSON size.

---
*PR created automatically by Jules for task [15163801829532326478](https://jules.google.com/task/15163801829532326478) started by @Akenaide*