### PR TITLE
⚡ Bolt: Offload Meilisearch calls to threads in resolvers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Async Strawberry GraphQL Resolvers
+**Learning:** In Strawberry GraphQL (version `0.316.0`), if a resolver function is `async def`, Strawberry automatically handles it internally and correctly `await`s it during query execution. No changes are required in the `strawberry.field(resolver=...)` definition or type hints, they seamlessly accept both sync and async functions without the rest of the application or the type annotations breaking.
+**Action:** When migrating synchronous resolvers to asynchronous ones to prevent event loop blocking, only the resolver function signature (`async def`) and its internal logic (like `asyncio.to_thread`) need to be updated. Type definitions on the Strawberry schema will continue working correctly without modification.

--- a/back/src/models/object_set.py
+++ b/back/src/models/object_set.py
@@ -1,3 +1,4 @@
+import asyncio
 from models.utils import pagination
 from config import get_settings
 import typing
@@ -20,24 +21,34 @@ class Set:
     product_type: str
 
 
-def get_sets(
+async def get_sets(
     page_size: int = settings.page_size,
     page_num: int = 1,
 ) -> typing.List[Set]:
     client = get_meili_client()
-    result = client.index("sets").search(
-        "", pagination(page_size=page_size, page_num=page_num)
-    )
+
+    # ⚡ Bolt: Offload synchronous Meilisearch call to a separate thread to prevent blocking the async event loop.
+    def fetch():
+        return client.index("sets").search(
+            "", pagination(page_size=page_size, page_num=page_num)
+        )
+
+    result = await asyncio.to_thread(fetch)
     return [Set(**dict(hit)) for hit in result["hits"]]
 
 
-def search_sets(
+async def search_sets(
     query: str,
     page_size: int = settings.page_size,
     page_num: int = 1,
 ) -> typing.List[Set]:
     client = get_meili_client()
-    result = client.index("sets").search(
-        query, pagination(page_size=page_size, page_num=page_num)
-    )
+
+    # ⚡ Bolt: Offload synchronous Meilisearch call to a separate thread to prevent blocking the async event loop.
+    def search():
+        return client.index("sets").search(
+            query, pagination(page_size=page_size, page_num=page_num)
+        )
+
+    result = await asyncio.to_thread(search)
     return [Set(**dict(hit)) for hit in result["hits"]]


### PR DESCRIPTION
💡 **What**: Refactored the `get_sets` and `search_sets` resolvers in `back/src/models/object_set.py` to be asynchronous and wrapped the synchronous Meilisearch API calls with `asyncio.to_thread`.
🎯 **Why**: The GraphQL resolvers were previously running synchronous network requests on the main thread, which blocks the event loop in FastAPI and degrades concurrent request performance.
📊 **Impact**: Prevents blocking of the async event loop during Meilisearch database lookups, greatly improving the backend's ability to handle concurrent requests under load.
🔬 **Measurement**: Verified the Strawberry GraphQL framework correctly `await`s the new async resolvers internally. Load tests would demonstrate improved throughput and reduced latency for concurrent connections.

---
*PR created automatically by Jules for task [12072550875355901206](https://jules.google.com/task/12072550875355901206) started by @Akenaide*