### PR TITLE
⚡ Bolt: Add GZip response compression

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - FastAPI GZip Middleware
+**Learning:** Adding GZipMiddleware is a low-effort, high-impact optimization for FastAPI/GraphQL backends where JSON payloads for lists/search can get large. It leverages built-in FastAPI tools.
+**Action:** When working on FastAPI applications serving JSON/GraphQL, proactively verify if response compression is enabled to reduce network transfer latency.

--- a/back/src/main.py
+++ b/back/src/main.py
@@ -6,6 +6,7 @@ import typing
 import strawberry
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from strawberry.fastapi import GraphQLRouter
 from fastapi.staticfiles import StaticFiles
 
@@ -33,6 +34,10 @@ class Query:
 
 app = FastAPI(lifespan=lifespan)
 app.mount("/medias", StaticFiles(directory=settings.medias_dir), name="medias")
+# ⚡ Bolt Optimization: Added GZipMiddleware to compress HTTP responses larger than 1000 bytes.
+# 🎯 Why: GraphQL responses (JSON) can get quite large. Compressing payloads significantly reduces network transfer times.
+# 📊 Impact: Expected to reduce payload sizes for list and search queries by ~70-80%, leading to faster client load times.
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
💡 What: Added GZipMiddleware to the FastAPI application to compress HTTP responses larger than 1000 bytes.
🎯 Why: GraphQL queries returning lists of sets or cards (JSON payloads) can become quite large.
📊 Impact: Expected to reduce payload sizes for list and search queries by ~70-80%, significantly reducing network transfer times and improving client load speed.
🔬 Measurement: Verify by inspecting the network tab in browser developer tools (or via curl) to see `Content-Encoding: gzip` and reduced transfer size for responses > 1KB.

---
*PR created automatically by Jules for task [3524155939964120378](https://jules.google.com/task/3524155939964120378) started by @Akenaide*